### PR TITLE
Apply #592 to other csproj files

### DIFF
--- a/tests/NSubstitute.Acceptance.Specs/NSubstitute.Acceptance.Specs.csproj
+++ b/tests/NSubstitute.Acceptance.Specs/NSubstitute.Acceptance.Specs.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>netcoreapp2.0;netcoreapp1.1;net46;net45</TargetFrameworks>
-
+    <TargetIsNetFx Condition="$(TargetFramework.StartsWith('net4'))">true</TargetIsNetFx>
     <!-- Enable the latest C# features -->
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
@@ -15,13 +15,18 @@
     <OutputPath>..\..\bin\Release\NSubstitute.Acceptance.Specs\</OutputPath>
   </PropertyGroup>
 
+  <!-- ReferenceAssemblies so we can build netfx targets on non-windows enviroments -->
+  <ItemGroup Condition="'$(TargetIsNetFx)' == 'true'">
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0-preview.2" PrivateAssets="All" />
+  </ItemGroup>
+
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
     <PackageReference Include="NUnit" Version="3.10.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.10.0" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)'=='net46' OR '$(TargetFramework)'=='net45'">
+  <ItemGroup Condition="'$(TargetIsNetFx)' == 'true'">
     <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
 

--- a/tests/NSubstitute.Benchmarks/NSubstitute.Benchmarks.csproj
+++ b/tests/NSubstitute.Benchmarks/NSubstitute.Benchmarks.csproj
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFrameworks>net462;netcoreapp2.1</TargetFrameworks>
+    <TargetIsNetFx Condition="$(TargetFramework.StartsWith('net4'))">true</TargetIsNetFx>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)'=='Debug'">
@@ -17,6 +18,12 @@
     <EmbeddedResource Remove="BenchmarkDotNet.Artifacts\**" />
     <None Remove="BenchmarkDotNet.Artifacts\**" />
   </ItemGroup>
+
+  <!-- ReferenceAssemblies so we can build netfx targets on non-windows enviroments -->
+  <ItemGroup Condition="'$(TargetIsNetFx)' == 'true'">
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0-preview.2" PrivateAssets="All" />
+  </ItemGroup>
+
   <ItemGroup>
     <PackageReference Include="BenchmarkDotNet" Version="0.10.14" />
     <ProjectReference Include="..\..\src\NSubstitute\NSubstitute.csproj" />


### PR DESCRIPTION
This makes ./build/build.sh compile correctly, but some tests currently
fail for netfx.

Running:

   > dotnet test -f netcoreapp2.0

from project root builds correctly.